### PR TITLE
chore: migrate to rules_bid 2.2.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 bazel_dep(name = "rules_distroless", version = "0.5.3")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "gotopt2", version = "2.2.2")
-bazel_dep(name = "bazel_rules_bid", version = "0.3.0")
+bazel_dep(name = "rules_bid", version = "2.2.2")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_oci", version = "2.2.6")
 bazel_dep(name = "rules_zstd", version = "1.0.0")


### PR DESCRIPTION
Migrates the repository to use `rules_bid` version 2.2.2 instead of the old `bazel_rules_bid` module name.

Commits:
- chore: migrate to rules_bid 2.2.2

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt:
for each repository so identified, check it out locally and migrate it from bazel_rules_bid to rules_bid version 2.2.2. rules_bid should only be used

for each, send PR that does this