### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,17 +3,17 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_distroless", version = "0.5.3")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "gotopt2", version = "2.2.2")
+bazel_dep(name = "rules_distroless", version = "0.8.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "gotopt2", version = "2.8.3")
 bazel_dep(name = "rules_bid", version = "2.2.2")
-bazel_dep(name = "rules_shell", version = "0.6.1")
-bazel_dep(name = "rules_oci", version = "2.2.6")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "rules_oci", version = "2.3.0")
 bazel_dep(name = "rules_zstd", version = "1.0.0")
 
 
 # multitool
-bazel_dep(name = "rules_multitool", version = "1.9.0")
+bazel_dep(name = "rules_multitool", version = "1.11.1")
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//:multitool.lock.json")
 use_repo(multitool, "multitool")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_distroless: 0.5.3 -> 0.8.0
* bazel_skylib: 1.7.1 -> 1.9.0
* gotopt2: 2.2.2 -> 2.8.3
* rules_shell: 0.6.1 -> 0.8.0
* rules_oci: 2.2.6 -> 2.3.0
* rules_multitool: 1.9.0 -> 1.11.1